### PR TITLE
Add DEEP FIELD main page and unify the site under the terminal design

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,9 +2,11 @@ import React from 'react';
 import { BrowserRouter, Route, Routes } from 'react-router';
 import Experience from 'pages/Experience';
 
-// Blog and the arcade pages are lazy so their chunks (markdown/syntax
-// highlighting, three.js) load only on their routes; Experience is the
-// landing route and renders without a chunk round-trip.
+// Blog and the three.js pages are lazy so their chunks (markdown/syntax
+// highlighting, three.js) load only on their routes. Home is the landing
+// route but still lazy — it needs the three.js chunk either way, and its
+// Suspense fallback below is a plain black screen so the swap is invisible.
+const Home = React.lazy(() => import('pages/Home'));
 const Blog = React.lazy(() => import('pages/Blog'));
 const Arcade = React.lazy(() => import('pages/Arcade'));
 const Ephemeris = React.lazy(() => import('pages/Ephemeris'));
@@ -45,7 +47,14 @@ function App() {
             <Route path="/blog" element={<Blog />} />
             <Route path="/arcade" element={<Arcade />} />
             <Route path="/ephemeris" element={<Ephemeris />} />
-            <Route path="/" element={<Experience />} />
+            <Route
+              path="/"
+              element={
+                <React.Suspense fallback={<div style={{ height: '100vh', background: '#000' }} />}>
+                  <Home />
+                </React.Suspense>
+              }
+            />
             <Route path="/experience" element={<Experience />} />
           </Routes>
         </React.Suspense>

--- a/src/components/deepfield/createDeepField.ts
+++ b/src/components/deepfield/createDeepField.ts
@@ -1,0 +1,300 @@
+import * as THREE from 'three';
+
+/** Per-body drift state kept outside the scene graph for type safety. */
+interface BodyState {
+  group: THREE.Group;
+  rot: THREE.Vector3;
+  vx: number;
+  vy: number;
+}
+
+/** Half-width / half-height of the corridor bodies spawn in. */
+const SPREAD_X = 620;
+const SPREAD_Y = 360;
+/** Bodies live between these z coords and recycle past NEAR. */
+const FAR = -2100;
+const NEAR = 90;
+/** Base drift speed (units/s); clicks multiply it via the throttle. */
+const BASE_SPEED = 34;
+const DUST_N = 300;
+const DUST_RANGE = 150;
+
+/**
+ * Mounts the DEEP FIELD backdrop into `container` and starts its render
+ * loop. Returns a dispose function that stops the loop, removes listeners
+ * and frees all GPU resources.
+ *
+ * An endless drift through wireframe planets, asteroids and derelicts.
+ * The cursor steers: the flight heading turns slowly toward where the
+ * cursor sits — off-center carves a wide banking turn, recentering flies
+ * straight — and the camera itself never jumps. Clicking kicks the drift
+ * speed (the throttle); holding the button sustains a full burn.
+ */
+export function createDeepField(container: HTMLElement): () => void {
+  const scene = new THREE.Scene();
+  scene.fog = new THREE.FogExp2(0x000000, 0.00115);
+  const camera = new THREE.PerspectiveCamera(
+    62,
+    container.clientWidth / Math.max(1, container.clientHeight),
+    0.1,
+    5000,
+  );
+  const renderer = new THREE.WebGLRenderer({ antialias: true });
+  renderer.setPixelRatio(Math.min(window.devicePixelRatio, 2));
+  renderer.setSize(container.clientWidth, container.clientHeight);
+  container.appendChild(renderer.domElement);
+
+  // ---- distant stars (rotate with the view, never translate) ----
+  {
+    const n = 900;
+    const positions = new Float32Array(n * 3);
+    for (let i = 0; i < n; i++) {
+      const v = new THREE.Vector3().randomDirection().multiplyScalar(1800 + Math.random() * 1400);
+      positions.set([v.x, v.y, v.z], i * 3);
+    }
+    const geometry = new THREE.BufferGeometry();
+    geometry.setAttribute('position', new THREE.BufferAttribute(positions, 3));
+    const stars = new THREE.Points(
+      geometry,
+      new THREE.PointsMaterial({ color: 0xffffff, size: 1.7, transparent: true, opacity: 0.5, fog: false }),
+    );
+    stars.frustumCulled = false;
+    scene.add(stars);
+  }
+
+  // ---- drifting wireframe bodies ----
+  const wire = (opacity: number) =>
+    new THREE.MeshBasicMaterial({ color: 0xffffff, wireframe: true, transparent: true, opacity });
+
+  function makeBody(): BodyState {
+    const group = new THREE.Group();
+    const kind = Math.random();
+    if (kind < 0.45) {
+      // asteroid — jittered dodecahedron
+      const r = 6 + Math.random() * 14;
+      const geo = new THREE.DodecahedronGeometry(r, 0);
+      const p = geo.attributes.position;
+      for (let i = 0; i < p.count; i++) {
+        const s = 0.75 + Math.random() * 0.5;
+        p.setXYZ(i, p.getX(i) * s, p.getY(i) * s, p.getZ(i) * s);
+      }
+      group.add(new THREE.Mesh(geo, wire(0.5)));
+    } else if (kind < 0.8) {
+      // planet, sometimes ringed
+      const r = 18 + Math.random() * 30;
+      group.add(new THREE.Mesh(new THREE.IcosahedronGeometry(r, 1), wire(0.45)));
+      if (Math.random() < 0.55) {
+        const ring = new THREE.Mesh(new THREE.TorusGeometry(r * 1.7, r * 0.015, 3, 56), wire(0.6));
+        ring.rotation.x = Math.PI / 2 + (Math.random() - 0.5) * 0.7;
+        group.add(ring);
+      }
+    } else {
+      // beacon / derelict — stacked octahedra
+      const r = 8 + Math.random() * 8;
+      const outer = new THREE.Mesh(new THREE.OctahedronGeometry(r, 0), wire(0.7));
+      const inner = new THREE.Mesh(new THREE.OctahedronGeometry(r * 0.55, 0), wire(0.9));
+      inner.rotation.z = Math.PI / 4;
+      group.add(outer, inner);
+    }
+    group.position.set(
+      (Math.random() - 0.5) * 2 * SPREAD_X,
+      (Math.random() - 0.5) * 2 * SPREAD_Y,
+      FAR + Math.random() * (NEAR - FAR),
+    );
+    scene.add(group);
+    return {
+      group,
+      rot: new THREE.Vector3(
+        (Math.random() - 0.5) * 0.4,
+        (Math.random() - 0.5) * 0.4,
+        (Math.random() - 0.5) * 0.4,
+      ),
+      vx: 0,
+      vy: 0,
+    };
+  }
+  const bodies = Array.from({ length: 26 }, makeBody);
+
+  // ---- dust for speed perception ----
+  const dustPositions = new Float32Array(DUST_N * 3);
+  for (let i = 0; i < DUST_N * 3; i++) dustPositions[i] = (Math.random() - 0.5) * DUST_RANGE * 2;
+  const dustGeo = new THREE.BufferGeometry();
+  dustGeo.setAttribute('position', new THREE.BufferAttribute(dustPositions, 3));
+  const dustSprite = (() => {
+    const c = document.createElement('canvas');
+    c.width = c.height = 32;
+    const g = c.getContext('2d')!;
+    const grad = g.createRadialGradient(16, 16, 0, 16, 16, 16);
+    grad.addColorStop(0, 'rgba(255,255,255,1)');
+    grad.addColorStop(0.5, 'rgba(255,255,255,.55)');
+    grad.addColorStop(1, 'rgba(255,255,255,0)');
+    g.fillStyle = grad;
+    g.fillRect(0, 0, 32, 32);
+    return new THREE.CanvasTexture(c);
+  })();
+  const dust = new THREE.Points(
+    dustGeo,
+    new THREE.PointsMaterial({
+      color: 0xffffff,
+      size: 1.5,
+      map: dustSprite,
+      transparent: true,
+      opacity: 0.34,
+      depthWrite: false,
+    }),
+  );
+  dust.frustumCulled = false;
+  scene.add(dust);
+
+  // ---- input ----
+  const raycaster = new THREE.Raycaster();
+  const ndc = new THREE.Vector2();
+  let mouseActive = false;
+  let throttleDown = false;
+  let boost = 1;
+
+  const onMouseMove = (e: MouseEvent) => {
+    const rect = renderer.domElement.getBoundingClientRect();
+    ndc.set(
+      ((e.clientX - rect.left) / rect.width) * 2 - 1,
+      -((e.clientY - rect.top) / rect.height) * 2 + 1,
+    );
+    mouseActive = true;
+  };
+  const onMouseLeave = () => {
+    mouseActive = false;
+  };
+  const onPointerDown = (e: PointerEvent) => {
+    // Links and buttons layered over the backdrop keep their normal clicks.
+    if (e.target instanceof Element && e.target.closest('a,button')) return;
+    throttleDown = true;
+    boost = Math.min(boost + 2.6, 8);
+  };
+  const onPointerUp = () => {
+    throttleDown = false;
+  };
+  const onResize = () => {
+    camera.aspect = container.clientWidth / Math.max(1, container.clientHeight);
+    camera.updateProjectionMatrix();
+    renderer.setSize(container.clientWidth, container.clientHeight);
+  };
+  window.addEventListener('mousemove', onMouseMove);
+  document.addEventListener('mouseleave', onMouseLeave);
+  window.addEventListener('pointerdown', onPointerDown);
+  window.addEventListener('pointerup', onPointerUp);
+  window.addEventListener('pointercancel', onPointerUp);
+  window.addEventListener('resize', onResize);
+
+  // ---- render loop ----
+  const clock = new THREE.Clock();
+  const heading = new THREE.Vector3(0, 0, -1);
+  const FORWARD = new THREE.Vector3(0, 0, -1);
+  const lookTarget = new THREE.Vector3();
+  let roll = 0;
+
+  renderer.setAnimationLoop(() => {
+    const dt = Math.min(clock.getDelta(), 0.05);
+    const t = clock.elapsedTime;
+
+    // throttle: click kicks, hold burns, release coasts back to cruise
+    if (throttleDown) boost += (8 - boost) * Math.min(1, dt * 1.6);
+    else boost += (1 - boost) * Math.min(1, dt * 1.1);
+    const speed = BASE_SPEED * boost;
+    const targetFov = 62 + (boost - 1) * 1.9;
+    if (Math.abs(camera.fov - targetFov) > 0.01) {
+      camera.fov += (targetFov - camera.fov) * Math.min(1, dt * 5);
+      camera.updateProjectionMatrix();
+    }
+
+    // camera: slow autonomous sway, never coupled to the cursor position
+    camera.position.x = Math.sin(t * 0.045) * 16;
+    camera.position.y = Math.cos(t * 0.036) * 10;
+    camera.position.z = 0;
+
+    // steering: the heading turns slowly toward the cursor's ray. With the
+    // camera looking along the heading, an off-center cursor is a constant
+    // angular offset — a steady, gentle turn; recentering flies straight.
+    if (mouseActive) {
+      raycaster.setFromCamera(ndc, camera);
+      heading.lerp(raycaster.ray.direction, Math.min(1, dt * 0.55));
+    } else {
+      heading.lerp(FORWARD, Math.min(1, dt * 0.08));
+    }
+    heading.y = THREE.MathUtils.clamp(heading.y, -0.55, 0.55);
+    heading.normalize();
+
+    lookTarget.copy(camera.position).addScaledVector(heading, 520);
+    lookTarget.x += Math.sin(t * 0.058) * 20;
+    lookTarget.y += Math.cos(t * 0.049) * 12;
+    camera.lookAt(lookTarget);
+    roll += (THREE.MathUtils.clamp(-heading.x * 0.45, -0.3, 0.3) - roll) * Math.min(1, dt * 2);
+    if (roll !== 0) camera.rotateZ(roll);
+
+    // bodies: the world slides past, opposite the heading
+    for (const b of bodies) {
+      b.group.position.addScaledVector(heading, -speed * dt);
+      b.group.position.x += b.vx * dt;
+      b.group.position.y += b.vy * dt;
+      b.vx *= Math.pow(0.35, dt);
+      b.vy *= Math.pow(0.35, dt);
+      b.group.rotation.x += b.rot.x * dt;
+      b.group.rotation.y += b.rot.y * dt;
+
+      if (b.group.position.z > NEAR) {
+        b.group.position.set(
+          (Math.random() - 0.5) * 2 * SPREAD_X,
+          (Math.random() - 0.5) * 2 * SPREAD_Y,
+          FAR + Math.random() * 120,
+        );
+        b.vx = b.vy = 0;
+      }
+      // lateral wrap so long turns never empty the field
+      if (Math.abs(b.group.position.x) > SPREAD_X * 1.8)
+        b.group.position.x -= Math.sign(b.group.position.x) * SPREAD_X * 3.6;
+      if (Math.abs(b.group.position.y) > SPREAD_Y * 1.8)
+        b.group.position.y -= Math.sign(b.group.position.y) * SPREAD_Y * 3.6;
+    }
+
+    // dust: streams past opposite the heading, recycled around the camera
+    const dp = dustGeo.attributes.position as THREE.BufferAttribute;
+    const dvx = -heading.x * speed * 2.4;
+    const dvy = -heading.y * speed * 2.4;
+    const dvz = -heading.z * speed * 2.4;
+    for (let i = 0; i < DUST_N; i++) {
+      let x = dp.getX(i) + dvx * dt;
+      let y = dp.getY(i) + dvy * dt;
+      let z = dp.getZ(i) + dvz * dt;
+      if (z > 30) {
+        z -= DUST_RANGE * 2;
+        x = (Math.random() - 0.5) * DUST_RANGE * 2;
+        y = (Math.random() - 0.5) * DUST_RANGE * 2;
+      }
+      if (Math.abs(x) > DUST_RANGE * 1.2) x -= Math.sign(x) * DUST_RANGE * 2.4;
+      if (Math.abs(y) > DUST_RANGE * 1.2) y -= Math.sign(y) * DUST_RANGE * 2.4;
+      dp.setXYZ(i, x, y, z);
+    }
+    dp.needsUpdate = true;
+
+    renderer.render(scene, camera);
+  });
+
+  return () => {
+    renderer.setAnimationLoop(null);
+    window.removeEventListener('mousemove', onMouseMove);
+    document.removeEventListener('mouseleave', onMouseLeave);
+    window.removeEventListener('pointerdown', onPointerDown);
+    window.removeEventListener('pointerup', onPointerUp);
+    window.removeEventListener('pointercancel', onPointerUp);
+    window.removeEventListener('resize', onResize);
+    scene.traverse((obj) => {
+      if (obj instanceof THREE.Mesh || obj instanceof THREE.Points || obj instanceof THREE.LineSegments) {
+        obj.geometry.dispose();
+        const material = obj.material as THREE.Material;
+        material.dispose();
+      }
+    });
+    dustSprite.dispose();
+    renderer.dispose();
+    renderer.domElement.remove();
+  };
+}

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -3,24 +3,27 @@ import {
   Box,
   Flex,
   Text,
-  Center,
   Spacer,
   Container,
   HStack,
   IconButton,
   VStack,
 } from '@chakra-ui/react';
-import { ColorModeButton } from 'components/ui/color-mode';
 import { Link as RouterLink, useLocation } from 'react-router';
 import { motion, AnimatePresence } from 'framer-motion';
 import { FaBars, FaTimes } from 'react-icons/fa';
 
 const MotionBox = motion(Box);
 
+const mono = {
+  fontFamily: 'ui-monospace, "SF Mono", Menlo, monospace',
+  color: 'white',
+} as const;
+
 const navItems = [
-  { name: 'Experience', path: '/experience' },
-  { name: 'Blog', path: '/blog' },
-  { name: 'Arcade', path: '/arcade' },
+  { name: 'EXPERIENCE', path: '/experience' },
+  { name: 'BLOG', path: '/blog' },
+  { name: 'PROJECTS', path: '/arcade' },
 ];
 
 const Header = () => {
@@ -32,64 +35,61 @@ const Header = () => {
   return (
     <>
       {/* Above all page content — the timeline uses z-indexes up to 100 internally. */}
-      <Box bg={{ base: 'gray.100', _dark: 'gray.900' }} p={3} position="sticky" top={0} zIndex={1100}>
-        <Container maxW="container.xl">
-          <Flex align="center">
+      <Box
+        bg="black"
+        px="34px"
+        py="20px"
+        position="sticky"
+        top={0}
+        zIndex={1100}
+        borderBottom="1px solid rgba(255,255,255,.15)"
+      >
+        <Container maxW="container.xl" px={0}>
+          <Flex align="baseline">
             <RouterLink to="/" style={{ textDecoration: 'none' }}>
-              <Center>
-                <Text fontSize="2xl" fontWeight="bold" color={{ base: 'gray.800', _dark: 'white' }}>
-                  Gabriel Rossi
-                </Text>
-              </Center>
+              <Text {...mono} fontSize="14px" fontWeight="bold" letterSpacing=".3em">
+                GROSSI.TECH
+              </Text>
             </RouterLink>
-            
+
             <Spacer />
-            
-            <HStack display={{ base: 'none', md: 'flex' }} gap={8} mr={8}>
+
+            <HStack display={{ base: 'none', md: 'flex' }} gap="26px">
               {navItems.map((item) => (
                 <RouterLink
                   key={item.path}
                   to={item.path}
                   style={{ textDecoration: 'none' }}
                 >
-                  <Box
-                    position="relative"
-                    color={{ base: 'gray.600', _dark: 'gray.300' }}
-                    fontWeight="medium"
-                    _hover={{
-                      color: { base: 'gray.900', _dark: 'white' }
-                    }}
+                  <Text
+                    {...mono}
+                    fontSize="12px"
+                    letterSpacing=".22em"
+                    opacity={isActive(item.path) ? 1 : 0.55}
+                    borderBottom={
+                      isActive(item.path)
+                        ? '1px solid rgba(255,255,255,.7)'
+                        : '1px solid transparent'
+                    }
+                    _hover={{ opacity: 1, borderBottomColor: 'whiteAlpha.500' }}
                   >
                     {item.name}
-                    {isActive(item.path) && (
-                      <MotionBox
-                        position="absolute"
-                        bottom="-8px"
-                        left={0}
-                        right={0}
-                        height="2px"
-                        bg={{ base: 'gray.900', _dark: 'gray.100' }}
-                        initial={{ scaleX: 0 }}
-                        animate={{ scaleX: 1 }}
-                        transition={{ duration: 0.3 }}
-                      />
-                    )}
-                  </Box>
+                  </Text>
                 </RouterLink>
               ))}
             </HStack>
-            
+
             <IconButton
               aria-label="Toggle menu"
               onClick={() => setIsMobileMenuOpen(!isMobileMenuOpen)}
               variant="ghost"
-              mr={2}
+              color="white"
+              borderRadius={0}
+              _hover={{ bg: 'whiteAlpha.200' }}
               display={{ base: 'flex', md: 'none' }}
             >
               {isMobileMenuOpen ? <FaTimes /> : <FaBars />}
             </IconButton>
-            
-            <ColorModeButton />
           </Flex>
         </Container>
       </Box>
@@ -98,11 +98,11 @@ const Header = () => {
         {isMobileMenuOpen && (
           <MotionBox
             position="fixed"
-            top="60px"
+            top="61px"
             left={0}
             right={0}
-            bg={{ base: 'white', _dark: 'gray.800' }}
-            shadow="lg"
+            bg="black"
+            borderBottom="1px solid rgba(255,255,255,.15)"
             zIndex={1000}
             initial={{ opacity: 0, y: -20 }}
             animate={{ opacity: 1, y: 0 }}
@@ -120,16 +120,23 @@ const Header = () => {
                 >
                   <Box
                     p={3}
-                    borderRadius="md"
-                    bg={isActive(item.path) ? { base: 'gray.200', _dark: 'gray.700' } : 'transparent'}
-                    color={isActive(item.path) ? { base: 'gray.900', _dark: 'gray.100' } : { base: 'gray.700', _dark: 'gray.300' }}
-                    fontWeight={isActive(item.path) ? 'bold' : 'medium'}
-                    _hover={{ 
-                      bg: { base: 'gray.100', _dark: 'gray.700' }
-                    }}
+                    borderRadius={0}
+                    border={
+                      isActive(item.path)
+                        ? '1px solid rgba(255,255,255,.35)'
+                        : '1px solid transparent'
+                    }
+                    _hover={{ bg: 'whiteAlpha.100' }}
                     display="block"
                   >
-                    {item.name}
+                    <Text
+                      {...mono}
+                      fontSize="12px"
+                      letterSpacing=".22em"
+                      opacity={isActive(item.path) ? 1 : 0.55}
+                    >
+                      {item.name}
+                    </Text>
                   </Box>
                 </RouterLink>
               ))}

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -18,7 +18,7 @@ import { FaBars, FaTimes } from 'react-icons/fa';
 const MotionBox = motion(Box);
 
 const navItems = [
-  { name: 'Experience', path: '/' },
+  { name: 'Experience', path: '/experience' },
   { name: 'Blog', path: '/blog' },
   { name: 'Arcade', path: '/arcade' },
 ];

--- a/src/components/layout/PageLayout.tsx
+++ b/src/components/layout/PageLayout.tsx
@@ -21,8 +21,8 @@ const PageLayout: React.FC<PageLayoutProps> = ({
   return (
     <Box
       minHeight="100vh"
-      bg={{ base: 'gray.50', _dark: 'gray.950' }}
-      color={{ base: 'gray.800', _dark: 'white' }}
+      bg="#080808"
+      color="white"
     >
       <Header />
       <Container maxW={maxW} px={px} py={py}>

--- a/src/components/post/Markdown.tsx
+++ b/src/components/post/Markdown.tsx
@@ -9,6 +9,26 @@ import { Box, Link, Text } from '@chakra-ui/react';
 // is ~800 kB. Register more here as posts need them.
 SyntaxHighlighter.registerLanguage('typescript', typescript);
 
+const mono = 'ui-monospace, "SF Mono", Menlo, monospace';
+
+// Strip emoji/pictographs so markdown titles render in the site's
+// plain terminal style even when the source file decorates them.
+const stripEmoji = (node: React.ReactNode): React.ReactNode => {
+  if (typeof node === 'string') {
+    return node.replace(/[\p{Extended_Pictographic}️]/gu, '').replace(/^\s+/, '');
+  }
+  if (Array.isArray(node)) return node.map(stripEmoji);
+  return node;
+};
+
+function MarkdownH1({ children, ...props }: any) {
+  return (
+    <Text {...props}>
+      {stripEmoji(children)}
+    </Text>
+  );
+}
+
 function MarkdownListItem(props: any) {
   return (
     <Box pl={16} py={1}>
@@ -32,7 +52,12 @@ function MarkdownCode(props: any) {
       <SyntaxHighlighter
         language={language}
         style={atomOneDarkReasonable}
-        customStyle={{ borderRadius: 6 }}
+        customStyle={{
+          borderRadius: 0,
+          border: '1px solid rgba(255,255,255,.2)',
+          background: '#050505',
+          fontFamily: mono,
+        }}
       >
         {code}
       </SyntaxHighlighter>
@@ -43,27 +68,51 @@ function MarkdownCode(props: any) {
 const options = {
   overrides: {
     h1: {
-      component: Text,
+      component: MarkdownH1,
       props: {
-        fontSize: '6xl',
-        my: 4,
+        fontSize: '3xl',
+        my: 6,
+        fontFamily: mono,
+        fontWeight: 'bold',
+        textTransform: 'uppercase',
+        letterSpacing: '.18em',
+        color: 'white',
       },
     },
     h2: {
       component: Text,
       props: {
-        fontSize: '4xl',
-        my: 2,
+        fontSize: 'xl',
+        my: 4,
+        fontFamily: mono,
+        fontWeight: 'bold',
+        textTransform: 'uppercase',
+        letterSpacing: '.16em',
+        color: 'white',
       },
     },
     h3: {
       component: Text,
-      props: { fontSize: '2xl', ml: 2, my: 2 },
+      props: {
+        fontSize: 'md',
+        ml: 2,
+        my: 3,
+        fontFamily: mono,
+        fontWeight: 'bold',
+        textTransform: 'uppercase',
+        letterSpacing: '.14em',
+        color: 'white',
+      },
     },
     h4: {
       component: Text,
       props: {
-        fontSize: 'lg',
+        fontSize: 'sm',
+        fontFamily: mono,
+        fontWeight: 'bold',
+        letterSpacing: '.12em',
+        textTransform: 'uppercase',
+        color: 'white',
       },
     },
     h5: {
@@ -71,6 +120,9 @@ const options = {
       props: {
         fontSize: 'xs',
         mx: [null, 2, 4, 6],
+        fontFamily: mono,
+        letterSpacing: '.12em',
+        color: 'whiteAlpha.700',
       },
     },
     p: {
@@ -79,9 +131,10 @@ const options = {
         fontSize: 'md',
         mx: [0, 0, 2, 4],
         mb: 4,
+        color: 'whiteAlpha.900',
       },
     },
-    a: { component: Link, props: { target: '_blank', rel: 'noopener noreferrer' } },
+    a: { component: Link, props: { target: '_blank', rel: 'noopener noreferrer', color: 'white', textDecoration: 'underline' } },
     li: {
       component: MarkdownListItem,
     },

--- a/src/components/post/Sidebar.tsx
+++ b/src/components/post/Sidebar.tsx
@@ -1,15 +1,32 @@
 import React from 'react';
-import { Box, Flex, Text, Center } from '@chakra-ui/react';
+import { Box, Flex, Text } from '@chakra-ui/react';
 import SocialLinks from 'components/post/SocialLinks';
 import { socialLinks } from 'config/site';
 
+const mono = 'ui-monospace, "SF Mono", Menlo, monospace';
+
 const Sidebar = () => {
   return (
-    <Box p={3}>
+    <Box
+      p={4}
+      bg="black"
+      border="1px solid rgba(255,255,255,.25)"
+      borderRadius={0}
+    >
       <Flex direction="column">
-        <Center>
-          <Text fontSize="2xl" color={{ base: "gray.800", _dark: "white" }}>Hello!</Text>
-        </Center>
+        <Text
+          fontFamily={mono}
+          fontSize="13px"
+          fontWeight="bold"
+          textTransform="uppercase"
+          letterSpacing=".26em"
+          color="white"
+          textAlign="left"
+          pb={3}
+          borderBottom="1px solid rgba(255,255,255,.15)"
+        >
+          Hello!
+        </Text>
         <SocialLinks links={socialLinks} />
       </Flex>
     </Box>

--- a/src/components/post/SocialLinks.tsx
+++ b/src/components/post/SocialLinks.tsx
@@ -1,7 +1,10 @@
 import * as React from "react";
-import { Box, Flex, Text, Link, Center, Icon } from "@chakra-ui/react";
-import { FaTwitter, FaLinkedin, FaGithub, FaRegEnvelope } from "react-icons/fa";
+import { Box, Flex, Text, Link, Icon } from "@chakra-ui/react";
+import { FaLinkedin, FaGithub, FaRegEnvelope } from "react-icons/fa";
+import { FaXTwitter } from "react-icons/fa6";
 import { SocialLinks as SocialLinksConfig } from "config/site";
+
+const mono = 'ui-monospace, "SF Mono", Menlo, monospace';
 
 export interface SocialLinksProps {
   links: SocialLinksConfig;
@@ -10,7 +13,7 @@ export interface SocialLinksProps {
 const linkItems: Array<{ key: keyof SocialLinksConfig; label: string; icon: React.ElementType }> = [
   { key: "linkedin", label: "LinkedIn", icon: FaLinkedin },
   { key: "github", label: "Github", icon: FaGithub },
-  { key: "twitter", label: "Twitter", icon: FaTwitter },
+  { key: "twitter", label: "X", icon: FaXTwitter },
   { key: "email", label: "Email", icon: FaRegEnvelope },
 ];
 
@@ -19,20 +22,37 @@ const SocialLinks = ({ links }: SocialLinksProps) => {
     <Box p={3}>
       <Flex direction="column">
         <Box
-          borderBottom="4px solid"
-          borderBottomColor={{ base: "gray.100", _dark: "gray.600" }}
+          borderBottom="1px solid rgba(255,255,255,.15)"
           py={1}
           mb={6}
         >
-          <Text fontSize="xl" color={{ base: "gray.800", _dark: "white" }}>Connect</Text>
+          <Text
+            fontFamily={mono}
+            fontSize="12px"
+            fontWeight="bold"
+            textTransform="uppercase"
+            letterSpacing=".26em"
+            color="white"
+            opacity={0.7}
+          >
+            Connect
+          </Text>
         </Box>
-        <Flex direction="column" gap={1}>
+        <Flex direction="column" gap={2}>
           {linkItems.map(({ key, label, icon }) => (
-            <Link key={key} href={links[key]} target="_blank" rel="noopener noreferrer">
-              <Center>
-                <Icon mr={2} as={icon} color={{ base: "gray.800", _dark: "white" }} />
-                <Text fontSize="lg" color={{ base: "gray.800", _dark: "white" }}>{label}</Text>
-              </Center>
+            <Link key={key} href={links[key]} target="_blank" rel="noopener noreferrer" _hover={{ textDecoration: 'none' }}>
+              <Flex align="center" justify="flex-start" gap={2} opacity={0.7} _hover={{ opacity: 1 }}>
+                <Icon as={icon} color="white" boxSize="14px" />
+                <Text
+                  fontFamily={mono}
+                  fontSize="12px"
+                  textTransform="uppercase"
+                  letterSpacing=".18em"
+                  color="white"
+                >
+                  {label}
+                </Text>
+              </Flex>
             </Link>
           ))}
         </Flex>

--- a/src/components/timeline/ExperienceHeader.tsx
+++ b/src/components/timeline/ExperienceHeader.tsx
@@ -1,24 +1,39 @@
 import React from 'react';
 import { VStack, Heading, Text } from '@chakra-ui/react';
 
+const mono = 'ui-monospace, "SF Mono", Menlo, monospace';
+
 interface ExperienceHeaderProps {
   title: string;
-  subtitle: string;
+  subtitle?: string;
 }
 
 const ExperienceHeader: React.FC<ExperienceHeaderProps> = ({ title, subtitle }) => {
   return (
     <VStack gap={4} textAlign="center">
       <Heading
-        size="4xl"
+        size="3xl"
+        fontFamily={mono}
         fontWeight="bold"
-        color={{ base: 'gray.900', _dark: 'white' }}
+        textTransform="uppercase"
+        letterSpacing=".22em"
+        color="white"
       >
         {title}
       </Heading>
-      <Text fontSize="lg" color={{ base: 'gray.600', _dark: 'gray.400' }} maxW="2xl">
-        {subtitle}
-      </Text>
+      {subtitle && (
+        <Text
+          fontFamily={mono}
+          fontSize="12px"
+          textTransform="uppercase"
+          letterSpacing=".26em"
+          color="white"
+          opacity={0.5}
+          maxW="2xl"
+        >
+          {subtitle}
+        </Text>
+      )}
     </VStack>
   );
 };

--- a/src/components/timeline/SkillsList.tsx
+++ b/src/components/timeline/SkillsList.tsx
@@ -1,6 +1,8 @@
 import React from 'react';
 import { Badge, HStack } from '@chakra-ui/react';
 
+const mono = 'ui-monospace, "SF Mono", Menlo, monospace';
+
 interface SkillsListProps {
   skills: string[];
   isLeft: boolean;
@@ -14,7 +16,19 @@ const SkillsList: React.FC<SkillsListProps> = ({ skills, isLeft }) => {
       justify={{ base: 'flex-start', md: isLeft ? 'flex-end' : 'flex-start' }}
     >
       {skills.map((skill) => (
-        <Badge key={skill} size="sm" variant="subtle">
+        <Badge
+          key={skill}
+          size="sm"
+          variant="outline"
+          borderRadius={0}
+          fontFamily={mono}
+          textTransform="uppercase"
+          letterSpacing=".12em"
+          bg="transparent"
+          color="whiteAlpha.700"
+          boxShadow="none"
+          border="1px solid rgba(255,255,255,0.25)"
+        >
           {skill}
         </Badge>
       ))}

--- a/src/components/timeline/TimelineCard.tsx
+++ b/src/components/timeline/TimelineCard.tsx
@@ -51,11 +51,10 @@ const TimelineCard: React.FC<TimelineCardProps> = ({ item, isLeft }) => {
       <MotionBox
         bg={timelineColors.cardBg}
         p={6}
-        borderRadius="xl"
+        borderRadius={0}
         borderWidth={1}
-        borderColor={item.highlight ? timelineColors.highlightColor : timelineColors.borderColor}
-        shadow={item.highlight ? 'lg' : 'md'}
-        whileHover={{ scale: 1.02, boxShadow: 'var(--chakra-shadows-xl)' }}
+        borderColor={item.highlight ? 'rgba(255,255,255,0.6)' : timelineColors.borderColor}
+        whileHover={{ scale: 1.02 }}
         transition={{ duration: 0.2 }}
         cursor="pointer"
         onClick={handleClick}
@@ -73,7 +72,7 @@ const TimelineCard: React.FC<TimelineCardProps> = ({ item, isLeft }) => {
           isLeft={isLeft}
         />
 
-        <Text fontSize="sm" color={{ base: 'gray.600', _dark: 'gray.400' }} mb={4}>
+        <Text fontSize="sm" color="whiteAlpha.700" mb={4}>
           {item.description}
         </Text>
 

--- a/src/components/timeline/TimelineIcon.tsx
+++ b/src/components/timeline/TimelineIcon.tsx
@@ -35,9 +35,9 @@ const TimelineIcon: React.FC<TimelineIconProps> = ({
   return (
     <MotionCircle
       size="60px"
-      bg={timelineColors.cardBg}
-      borderWidth={3}
-      borderColor={isHighlighted ? timelineColors.highlightColor : timelineColors.lineColor}
+      bg="black"
+      borderWidth={1}
+      borderColor={isHighlighted ? 'rgba(255,255,255,0.8)' : 'rgba(255,255,255,0.35)'}
       zIndex={50}
       whileHover={{ scale: 1.2 }}
       transition={{ duration: 0.2 }}

--- a/src/components/timeline/TimelineItemHeader.tsx
+++ b/src/components/timeline/TimelineItemHeader.tsx
@@ -1,7 +1,9 @@
 import React from 'react';
 import { Badge, HStack, Heading, Text } from '@chakra-ui/react';
 import { TimelineItem } from 'components/timeline/types';
-import { timelineColors, typeColorPalettes } from 'components/timeline/config';
+import { timelineColors } from 'components/timeline/config';
+
+const mono = 'ui-monospace, "SF Mono", Menlo, monospace';
 
 interface TimelineItemHeaderProps {
   type: TimelineItem['type'];
@@ -24,20 +26,42 @@ const TimelineItemHeader: React.FC<TimelineItemHeaderProps> = ({
         justify={{ base: 'flex-start', md: isLeft ? 'flex-end' : 'flex-start' }}
         mb={2}
       >
-        <Badge colorPalette={typeColorPalettes[type] ?? 'gray'} size="sm" variant="subtle">
+        <Badge
+          size="sm"
+          variant="outline"
+          borderRadius={0}
+          fontFamily={mono}
+          textTransform="uppercase"
+          letterSpacing=".14em"
+          bg="transparent"
+          color="whiteAlpha.800"
+          boxShadow="none"
+          border="1px solid rgba(255,255,255,0.3)"
+        >
           {type}
         </Badge>
-        <Text fontSize="sm" color={{ base: 'gray.600', _dark: 'gray.400' }}>
+        <Text fontFamily={mono} fontSize="xs" letterSpacing=".1em" color="whiteAlpha.600">
           {period}
         </Text>
       </HStack>
-      <Heading size="md" mb={1} color={{ base: 'gray.800', _dark: 'white' }}>
+      <Heading
+        size="sm"
+        mb={1}
+        fontFamily={mono}
+        textTransform="uppercase"
+        letterSpacing=".16em"
+        color="white"
+      >
         {title}
       </Heading>
       <Text
-        fontSize="sm"
+        fontFamily={mono}
+        fontSize="xs"
         fontWeight="semibold"
+        textTransform="uppercase"
+        letterSpacing=".18em"
         color={timelineColors.highlightColor}
+        opacity={0.8}
         mb={3}
       >
         {organization}

--- a/src/components/timeline/config.ts
+++ b/src/components/timeline/config.ts
@@ -1,12 +1,11 @@
 import { TimelineColors, TimelineItem, TimelineParticleConfig } from 'components/timeline/types';
 
-// Chakra conditional tokens resolve per color mode, so no useColorMode needed.
-// Black-and-white palette: neutral grays only.
+// Terminal wireframe palette: black surfaces, thin white-alpha strokes.
 export const timelineColors: TimelineColors = {
-  cardBg: { base: 'white', _dark: 'gray.800' },
-  borderColor: { base: 'gray.200', _dark: 'gray.700' },
-  lineColor: { base: 'gray.300', _dark: 'gray.600' },
-  highlightColor: { base: 'gray.900', _dark: 'gray.100' },
+  cardBg: 'black',
+  borderColor: 'rgba(255,255,255,0.25)',
+  lineColor: 'rgba(255,255,255,0.2)',
+  highlightColor: 'white',
 };
 
 export const typeColorPalettes: Record<TimelineItem['type'], string> = {

--- a/src/components/ui/color-mode.tsx
+++ b/src/components/ui/color-mode.tsx
@@ -11,8 +11,9 @@ export function ColorModeProvider({ children }: ColorModeProviderProps) {
   return (
     <NextThemesProvider
       attribute="class"
-      defaultTheme="system"
-      enableSystem={true}
+      defaultTheme="dark"
+      forcedTheme="dark"
+      enableSystem={false}
       disableTransitionOnChange
     >
       {children}

--- a/src/index.css
+++ b/src/index.css
@@ -1,3 +1,9 @@
+html {
+  /* Reserve the scrollbar gutter on every page so the centered header
+     doesn't shift between scrolling pages and 100vh pages (Home). */
+  scrollbar-gutter: stable;
+}
+
 body {
   margin: 0;
   font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen',
@@ -6,23 +12,13 @@ body {
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
   min-height: 100vh;
-  transition: background-color 0.2s ease, color 0.2s ease;
-}
-
-/* Light mode */
-body {
-  background-color: white;
-  color: #1a202c;
-}
-
-/* Dark mode */
-body.dark {
-  background-color: #1a202c;
+  /* Dark-only terminal theme. */
+  background-color: #080808;
   color: white;
 }
 
 code {
-  font-family: source-code-pro, Menlo, Monaco, Consolas, 'Courier New',
+  font-family: ui-monospace, 'SF Mono', Menlo, Monaco, Consolas, 'Courier New',
     monospace;
 }
 

--- a/src/pages/Arcade.tsx
+++ b/src/pages/Arcade.tsx
@@ -2,6 +2,8 @@ import { Box, Flex, Heading, SimpleGrid, Text } from '@chakra-ui/react';
 import { Link as RouterLink } from 'react-router';
 import PageLayout from 'components/layout/PageLayout';
 
+const mono = 'ui-monospace, "SF Mono", Menlo, monospace';
+
 interface Demo {
   slug: string;
   title: string;
@@ -108,36 +110,36 @@ const CardShell = ({ demo }: { demo: Demo }) => (
     height="100%"
     p={5}
     borderWidth="1px"
-    borderColor={{ base: 'gray.300', _dark: 'gray.700' }}
-    bg={{ base: 'white', _dark: 'black' }}
+    borderColor="#3f3f46"
+    bg="black"
     transition="border-color 0.15s ease, transform 0.15s ease"
     _hover={{
-      borderColor: { base: 'gray.900', _dark: 'white' },
+      borderColor: 'white',
       transform: 'translateY(-2px)',
     }}
   >
     <Flex align="baseline" justify="space-between" gap={2}>
-      <Heading as="h3" size="md" fontFamily="mono" letterSpacing="0.15em">
+      <Heading as="h3" size="md" fontFamily={mono} fontWeight="bold" letterSpacing="0.15em">
         {demo.title}
       </Heading>
       <Text
         fontSize="xs"
-        fontFamily="mono"
+        fontFamily={mono}
         letterSpacing="0.1em"
-        color={{ base: 'gray.500', _dark: 'gray.400' }}
+        color="#a1a1aa"
         flexShrink={0}
       >
         {demo.featured ? '★ featured' : demo.kind}
       </Text>
     </Flex>
-    <Text mt={1} fontSize="sm" fontStyle="italic" color={{ base: 'gray.600', _dark: 'gray.400' }}>
+    <Text mt={1} fontSize="sm" fontStyle="italic" color="#a1a1aa">
       {demo.tagline}
     </Text>
-    <Text mt={3} fontSize="sm" flex="1">
+    <Text mt={3} fontSize="sm" flex="1" lineHeight="1.5">
       {demo.description}
     </Text>
-    <Flex mt={4} align="center" justify="space-between" fontFamily="mono" fontSize="xs">
-      <Text color={{ base: 'gray.500', _dark: 'gray.500' }} letterSpacing="0.08em">
+    <Flex mt={4} align="center" justify="space-between" fontFamily={mono} fontSize="xs">
+      <Text color="#71717a" letterSpacing="0.08em">
         {demo.controls}
       </Text>
       <Text fontWeight="bold" letterSpacing="0.25em">
@@ -149,12 +151,11 @@ const CardShell = ({ demo }: { demo: Demo }) => (
 
 const Arcade = () => (
   <PageLayout>
-    <Heading as="h1" size="2xl" fontFamily="mono" letterSpacing="0.1em">
-      ARCADE
+    <Heading as="h1" size="2xl" fontFamily={mono} fontWeight="bold" letterSpacing="0.1em">
+      PROJECTS
     </Heading>
-    <Text mt={3} maxW="2xl" color={{ base: 'gray.600', _dark: 'gray.400' }}>
-      Nine little three.js experiments in black and white — arcade games and ambient simulations.
-      Each one is a single small file; nothing to install, nothing to lose.
+    <Text mt={3} maxW="2xl" color="#a1a1aa" lineHeight="1.5">
+      Demos and personal experiments
     </Text>
     <SimpleGrid columns={{ base: 1, md: 2, lg: 3 }} gap={5} mt={10}>
       {demos.map((demo) =>

--- a/src/pages/Experience.tsx
+++ b/src/pages/Experience.tsx
@@ -12,10 +12,7 @@ const Experience: React.FC = () => {
   return (
     <PageLayout maxW="container.lg">
       <VStack gap={16}>
-        <ExperienceHeader
-          title="Professional Journey"
-          subtitle="A decade of growth, learning, and building impactful solutions"
-        />
+        <ExperienceHeader title="Professional Journey" />
 
         <Timeline items={timelineItems} />
       </VStack>

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -1,0 +1,91 @@
+import { useEffect, useRef } from 'react';
+import { Box, Flex, HStack, Text } from '@chakra-ui/react';
+import { Link as RouterLink } from 'react-router';
+import { createDeepField } from 'components/deepfield/createDeepField';
+
+const mono = {
+  fontFamily: 'ui-monospace, "SF Mono", Menlo, monospace',
+  color: 'white',
+} as const;
+
+const navItems = [
+  { name: 'BLOG', path: '/blog' },
+  { name: 'EXPERIENCE', path: '/experience' },
+  { name: 'ARCADE', path: '/arcade' },
+];
+
+// The main page: the DEEP FIELD wireframe drift as a full-screen backdrop
+// with the site's front door layered on top. Overlay content ignores the
+// pointer (except links) so the field receives every steer and click.
+const Home = () => {
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (!containerRef.current) return;
+    return createDeepField(containerRef.current);
+  }, []);
+
+  return (
+    <Box position="relative" height="100vh" overflow="hidden" bg="black">
+      <Box ref={containerRef} position="absolute" inset={0} />
+
+      <Flex
+        position="absolute"
+        inset={0}
+        direction="column"
+        pointerEvents="none"
+        userSelect="none"
+      >
+        <Flex justify="space-between" align="baseline" px="34px" py="26px">
+          <Text {...mono} fontSize="14px" fontWeight="bold" letterSpacing=".3em">
+            GROSSI.TECH
+          </Text>
+          <HStack gap="26px">
+            {navItems.map((item) => (
+              <RouterLink
+                key={item.path}
+                to={item.path}
+                style={{ pointerEvents: 'auto', textDecoration: 'none' }}
+              >
+                <Text
+                  {...mono}
+                  fontSize="12px"
+                  letterSpacing=".22em"
+                  opacity={0.55}
+                  borderBottom="1px solid transparent"
+                  _hover={{ opacity: 1, borderBottomColor: 'whiteAlpha.500' }}
+                >
+                  {item.name}
+                </Text>
+              </RouterLink>
+            ))}
+          </HStack>
+        </Flex>
+
+        <Flex flex="1" direction="column" justify="center" px="34px" maxW="720px">
+          <Text
+            as="h1"
+            {...mono}
+            fontSize="clamp(34px, 7vw, 72px)"
+            fontWeight="bold"
+            letterSpacing=".14em"
+            lineHeight="1.05"
+            textShadow="0 0 24px rgba(0,0,0,.9)"
+          >
+            GABRIEL
+            <br />
+            ROSSI
+          </Text>
+          <Text {...mono} mt="14px" fontSize="13px" letterSpacing=".34em" opacity={0.6}>
+            SOFTWARE ENGINEER
+          </Text>
+          <Text {...mono} mt="42px" fontSize="11px" letterSpacing=".26em" opacity={0.35}>
+            STEER WITH THE MOUSE &middot; CLICK TO KICK &middot; HOLD TO BURN
+          </Text>
+        </Flex>
+      </Flex>
+    </Box>
+  );
+};
+
+export default Home;

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useRef } from 'react';
-import { Box, Flex, HStack, Text } from '@chakra-ui/react';
-import { Link as RouterLink } from 'react-router';
+import { Box, Flex, Text } from '@chakra-ui/react';
+import Header from 'components/layout/Header';
 import { createDeepField } from 'components/deepfield/createDeepField';
 
 const mono = {
@@ -8,15 +8,10 @@ const mono = {
   color: 'white',
 } as const;
 
-const navItems = [
-  { name: 'BLOG', path: '/blog' },
-  { name: 'EXPERIENCE', path: '/experience' },
-  { name: 'ARCADE', path: '/arcade' },
-];
-
-// The main page: the DEEP FIELD wireframe drift as a full-screen backdrop
-// with the site's front door layered on top. Overlay content ignores the
-// pointer (except links) so the field receives every steer and click.
+// The main page: the shared header on top and the DEEP FIELD wireframe
+// drift filling the rest of the viewport, with the hero layered on top.
+// Overlay content ignores the pointer so the field receives every steer
+// and click.
 const Home = () => {
   const containerRef = useRef<HTMLDivElement>(null);
 
@@ -26,65 +21,44 @@ const Home = () => {
   }, []);
 
   return (
-    <Box position="relative" height="100vh" overflow="hidden" bg="black">
-      <Box ref={containerRef} position="absolute" inset={0} />
+    <Flex direction="column" height="100vh" overflow="hidden" bg="black">
+      <Header />
 
-      <Flex
-        position="absolute"
-        inset={0}
-        direction="column"
-        pointerEvents="none"
-        userSelect="none"
-      >
-        <Flex justify="space-between" align="baseline" px="34px" py="26px">
-          <Text {...mono} fontSize="14px" fontWeight="bold" letterSpacing=".3em">
-            GROSSI.TECH
-          </Text>
-          <HStack gap="26px">
-            {navItems.map((item) => (
-              <RouterLink
-                key={item.path}
-                to={item.path}
-                style={{ pointerEvents: 'auto', textDecoration: 'none' }}
+      <Box position="relative" flex="1" overflow="hidden">
+        <Box ref={containerRef} position="absolute" inset={0} />
+
+        <Flex
+          position="absolute"
+          inset={0}
+          direction="column"
+          justify="center"
+          pointerEvents="none"
+          userSelect="none"
+          px="34px"
+        >
+          <Box maxW="1280px" mx="auto" w="100%">
+            <Flex direction="column" maxW="720px">
+              <Text
+                as="h1"
+                {...mono}
+                fontSize="clamp(34px, 7vw, 72px)"
+                fontWeight="bold"
+                letterSpacing=".14em"
+                lineHeight="1.05"
+                textShadow="0 0 24px rgba(0,0,0,.9)"
               >
-                <Text
-                  {...mono}
-                  fontSize="12px"
-                  letterSpacing=".22em"
-                  opacity={0.55}
-                  borderBottom="1px solid transparent"
-                  _hover={{ opacity: 1, borderBottomColor: 'whiteAlpha.500' }}
-                >
-                  {item.name}
-                </Text>
-              </RouterLink>
-            ))}
-          </HStack>
+                GABRIEL
+                <br />
+                ROSSI
+              </Text>
+              <Text {...mono} mt="14px" fontSize="13px" letterSpacing=".34em" opacity={0.6}>
+                SOFTWARE ENGINEER
+              </Text>
+            </Flex>
+          </Box>
         </Flex>
-
-        <Flex flex="1" direction="column" justify="center" px="34px" maxW="720px">
-          <Text
-            as="h1"
-            {...mono}
-            fontSize="clamp(34px, 7vw, 72px)"
-            fontWeight="bold"
-            letterSpacing=".14em"
-            lineHeight="1.05"
-            textShadow="0 0 24px rgba(0,0,0,.9)"
-          >
-            GABRIEL
-            <br />
-            ROSSI
-          </Text>
-          <Text {...mono} mt="14px" fontSize="13px" letterSpacing=".34em" opacity={0.6}>
-            SOFTWARE ENGINEER
-          </Text>
-          <Text {...mono} mt="42px" fontSize="11px" letterSpacing=".26em" opacity={0.35}>
-            STEER WITH THE MOUSE &middot; CLICK TO KICK &middot; HOLD TO BURN
-          </Text>
-        </Flex>
-      </Flex>
-    </Box>
+      </Box>
+    </Flex>
   );
 };
 


### PR DESCRIPTION
## Summary
- New `/` route: **DEEP FIELD** — a full-screen three.js backdrop in the EPHEMERIS wireframe style (endless drift past procedural planets, ringed giants, asteroids and derelicts), with the site's front door layered on top.
- **Mouse steers** the flight: the heading turns slowly toward the cursor with a gentle bank; the camera never jumps or parallaxes. **Click** kicks the drift speed; **hold** sustains a full burn; release coasts back to cruise.
- **Site-wide design unification** (ported from the owner's Claude Design iteration): one shared GROSSI.TECH mono header on every page including Home; dark-only theme (color-mode toggle removed); Experience timeline restyled to square-cornered black cards with white-alpha borders and mono-caps titles/chips; Blog gets terminal headings, bordered code blocks, and a left-aligned HELLO!/CONNECT sidebar with X replacing Twitter; Arcade is renamed **PROJECTS** ("Demos and personal experiments").
- Experience moves to `/experience`; `scrollbar-gutter: stable` keeps the centered header from shifting between scrolling pages and 100vh pages.
- Design provenance: chosen via the bg-picks boards (https://bg-picks.vercel.app) and a full-terminal vs full-sans variant comparison, then refined in Claude Design.

Stacked on #6 (needs the `three` dependency and arcade routes) — merge that first; GitHub will retarget this PR to `main` automatically.

## Test plan
- `npm run build` (tsc + vite) passes.
- Verified in Chrome against the Claude Design mockups: all five design iterations present (PROJECTS rename, subtitle removals, left-aligned sidebar, X icon, hint text removed).
- Header geometry measured identical (`logoLeft` equal on Home/Blog/Experience) after the scrollbar-gutter fix.
- Steering, throttle, and route transitions (mount/dispose of the sim) verified with no console errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)